### PR TITLE
style: 스토어 디테일 페이지 구성요소 변경 및 북마크 버튼 추가

### DIFF
--- a/src/components/ProductInfo/index.tsx
+++ b/src/components/ProductInfo/index.tsx
@@ -17,7 +17,7 @@ interface IProductInfo {
 const productData: IProductInfo = {
   id: 1,
   name: "충주 유기농 사과 1박스",
-  desc: "충북 충주시에서 직접 수확한 유기농 사과입니다.충북 충주시에서 직접 수확한 유기농 사과입니다.충북 충주시에서 직접 수확한 유기농 사과입니다.충북 충주시에서 직접 수확한 유기농 사과입니다.",
+  desc: "충북 충주시에서 직접 수확한 유기농 사과입니다.",
   img: "https://images.unsplash.com/photo-1584306670957-acf935f5033c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=986&q=80",
   price: 12000,
   delivery: 3000,
@@ -55,7 +55,7 @@ function ProductInfo() {
               <BookmarkIcon activate={bookmarked} />
             </Box>
           </Flex>
-          <Text mt={8} fontSize="14px" color="gray.700">
+          <Text mt={3} fontSize="14px" color="gray.500">
             {productData.desc}
           </Text>
         </Box>

--- a/src/components/ProductInfo/index.tsx
+++ b/src/components/ProductInfo/index.tsx
@@ -1,15 +1,6 @@
-import {
-  Flex,
-  Image,
-  Box,
-  Text,
-  HStack,
-  Button,
-  Wrap,
-  WrapItem,
-  VStack,
-} from "@chakra-ui/react";
-import { MinusIcon, PlusOutLineIcon } from "components/Icon";
+import { Flex, Image, Box, Text, HStack, Button } from "@chakra-ui/react";
+import { BookmarkIcon, MinusIcon, PlusOutLineIcon } from "components/Icon";
+import { useState } from "react";
 
 interface IProductInfo {
   id: number;
@@ -17,6 +8,7 @@ interface IProductInfo {
   desc: string;
   price: number;
   delivery: number;
+  volume: string;
   company: string;
   bookmarked: boolean;
   img: string;
@@ -29,11 +21,18 @@ const productData: IProductInfo = {
   img: "https://images.unsplash.com/photo-1584306670957-acf935f5033c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=986&q=80",
   price: 12000,
   delivery: 3000,
+  volume: "약 300g*30개",
   company: "충주사과",
   bookmarked: false,
 };
 
 function ProductInfo() {
+  const [bookmarked, setBookmarked] = useState(productData.bookmarked);
+
+  function bookmarkClick() {
+    setBookmarked(!bookmarked);
+  }
+
   return (
     <Flex my={20}>
       <Image
@@ -48,15 +47,24 @@ function ProductInfo() {
           <Text fontSize="14px" color="orange.400" fontWeight="500">
             {productData.company}
           </Text>
-          <Text my={5} fontSize="24px" fontWeight="500">
-            {productData.name}
-          </Text>
-          <Text mt={16} fontSize="14px" color="gray.700">
+          <Flex my={5} mr={3} justifyContent="space-between">
+            <Text fontSize="24px" fontWeight="500">
+              {productData.name}
+            </Text>
+            <Box cursor={"pointer"} onClick={bookmarkClick}>
+              <BookmarkIcon activate={bookmarked} />
+            </Box>
+          </Flex>
+          <Text mt={8} fontSize="14px" color="gray.700">
             {productData.desc}
           </Text>
         </Box>
-
-        <HStack mt={16} justifyContent="space-between">
+        <HStack
+          py={14}
+          justifyContent="space-between"
+          borderBottom="1px"
+          borderColor="gray.200"
+        >
           <Box>
             <Text fontSize="30px" fontWeight="700">
               {productData.price} 원
@@ -66,11 +74,26 @@ function ProductInfo() {
               {productData.delivery ? productData.delivery + " 원" : "무로"}
             </Text>
           </Box>
-          <Counter />
         </HStack>
-        <Box mt={60}>
+        <Box>
+          <Box mb={20}>
+            <Flex my={10} alignItems="center">
+              <Text fontSize="15px" fontWeight="400" mr={10}>
+                용량/중량
+              </Text>
+              <Text fontSize="15px" fontWeight="400">
+                {productData.volume}
+              </Text>
+            </Flex>
+            <Flex my={10} alignItems="center">
+              <Text fontSize="15px" fontWeight="400" mr={10}>
+                구매 수량
+              </Text>
+              <Counter />
+            </Flex>
+          </Box>
           <Flex alignItems="center" justifyContent="space-between">
-            <Text fontSize="20px" fontWeight="500">
+            <Text fontSize="15px" fontWeight="500">
               주문금액
             </Text>
             <Text fontSize="26px" fontWeight="700">


### PR DESCRIPTION
<img width="1047" alt="스크린샷 2022-06-17 오후 6 10 22" src="https://user-images.githubusercontent.com/73513965/174267068-d1e44829-c84c-4dd3-a5aa-ecd3583b35ad.png">

기존 스토어 디테일 페이지의 UI가 너무 휑해보여서 제품별 용량/중량 정보를 추가했고, 화면이 덜 비어보이도록 컴포넌트들 위치와 간격을 재배치했습니다. 또한 북마크버튼도 추가했어요 😊